### PR TITLE
Redundant elif - LTS OS Description

### DIFF
--- a/rolling-rhino
+++ b/rolling-rhino
@@ -80,7 +80,7 @@ OS_DESCRIPTION=$(lsb_release --description --short)
 if [[ "${OS_DESCRIPTION}" == *"development branch"* ]]; then
   fancy_message 0 "${OS_DESCRIPTION} detected."
 elif  [[ "${OS_DESCRIPTION}" == *"LTS"* ]]; then
-  fancy_message 2 "${OS_DESCRIPTION} detected, which is not supported."
+  fancy_message 2 "${OS_DESCRIPTION} detected, which is not supported. Only daily/development Ubuntu releases are supported."
   exit 1
 else
   fancy_message 2 "${OS_DESCRIPTION} detected, which is not supported."


### PR DESCRIPTION
"LTS" elif statement is redundant as they will get an identical message from the else statement if the elif statement were removed.

Add specific context to the elif statement pertaining to LTS as seen below or remove the redundancy.