### PR TITLE
Correct the heredoc usage

### DIFF
--- a/rolling-rhino
+++ b/rolling-rhino
@@ -112,7 +112,7 @@ fancy_message 0 "All checks passed."
 read -p "Are you sure you want to start tracking the devel series? [Y/N]" -n 1 -r
 if [[ ${REPLY} =~ ^[Yy]$ ]]; then
     cp  /etc/apt/sources.list /etc/apt/sources.list.${OS_CODENAME}
-    cat < EOM > /etc/apt/sources.list
+    cat << EOF > /etc/apt/sources.list
 # See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
 # newer versions of the distribution.
 deb http://archive.ubuntu.com/ubuntu devel main restricted
@@ -162,7 +162,7 @@ deb http://security.ubuntu.com/ubuntu devel-security universe
 # deb-src http://security.ubuntu.com/ubuntu devel-security universe
 deb http://security.ubuntu.com/ubuntu devel-security multiverse
 # deb-src http://security.ubuntu.com/ubuntu devel-security multiverse
-EOM
+EOF
 
     fancy_message 0 "Switching to devel series."
     apt -y autoclean


### PR DESCRIPTION
This will overwrite /etc/apt/sources.list correctly and fixes https://github.com/wimpysworld/rolling-rhino/issues/11

Tested using todays daily groovy
```
lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu Groovy Gorilla (development branch)
Release:	20.10
Codename:	groovy

sudo ./rolling-rhino 
Rolling Rhino 🦏
  [+] INFO: lsb_release detected.
  [!] ERROR: Already tracking the devel series. Nothing to do.
```