### PR TITLE
Update the question

### DIFF
--- a/rolling-rhino
+++ b/rolling-rhino
@@ -109,7 +109,7 @@ else
 fi
 
 fancy_message 0 "All checks passed."
-read -p "Are you sure you want to start tracking the devel series? [Y/N]" -n 1 -r
+read -p "Are you sure you want to start tracking the devel series? [y/N]" -n 1 -r
 if [[ ${REPLY} =~ ^[Yy]$ ]]; then
     cp  /etc/apt/sources.list /etc/apt/sources.list.${OS_CODENAME}
     cat << EOF > /etc/apt/sources.list


### PR DESCRIPTION
- In most distros, a capital letter indicates the default choice
  if no option is chosen and <kbd>Enter</kbd> is pressed. As this command
  will not continue when simply pressing <kbd>Enter</kbd> , the option should
  be shown as `[y/N]` - thus indicating that `No` is the default option