### PR TITLE
Fix detection of desktop packages on non-english systems

### DIFF
--- a/rolling-rhino
+++ b/rolling-rhino
@@ -89,7 +89,7 @@ fi
 
 DESKTOP_FOUND=0
 for META in kubuntu-desktop lubuntu-desktop ubuntu-desktop ubuntu-budgie-desktop ubuntukylin-desktop ubuntu-mate-desktop ubuntustudio-desktop xubuntu-desktop; do
-  INSTALLED=$(LANG=C apt list --installed "${META}" 2>/dev/null | grep installed)
+  INSTALLED=$(env LANG=C apt list --installed "${META}" 2>/dev/null | grep installed)
   if [ -n "${INSTALLED}" ]; then
     fancy_message 0 "Detected ${META}."
     DESKTOP_FOUND=1

--- a/rolling-rhino
+++ b/rolling-rhino
@@ -89,7 +89,7 @@ fi
 
 DESKTOP_FOUND=0
 for META in kubuntu-desktop lubuntu-desktop ubuntu-desktop ubuntu-budgie-desktop ubuntukylin-desktop ubuntu-mate-desktop ubuntustudio-desktop xubuntu-desktop; do
-  INSTALLED=$(apt list --installed "${META}" 2>/dev/null | grep installed)
+  INSTALLED=$(LANG=C apt list --installed "${META}" 2>/dev/null | grep installed)
   if [ -n "${INSTALLED}" ]; then
     fancy_message 0 "Detected ${META}."
     DESKTOP_FOUND=1


### PR DESCRIPTION
Currently, the script detects the availability of a suitable desktop environment/meta package by searching for the string `installed` when looking at the packages list.

This will fail on systems that use other languages than English by default. By enforcing `LANG=C` when launching `apt list`, we can circumvent this. Tested on a German installation right now.