### PR TITLE
Support WSL by adding ubuntu-wsl to list of desktop meta-packages

### DIFF
--- a/rolling-rhino
+++ b/rolling-rhino
@@ -88,7 +88,7 @@ else
 fi
 
 DESKTOP_FOUND=0
-for META in kubuntu-desktop lubuntu-desktop ubuntu-desktop ubuntu-budgie-desktop ubuntukylin-desktop ubuntu-mate-desktop ubuntustudio-desktop xubuntu-desktop; do
+for META in kubuntu-desktop lubuntu-desktop ubuntu-desktop ubuntu-budgie-desktop ubuntukylin-desktop ubuntu-mate-desktop ubuntustudio-desktop xubuntu-desktop ubuntu-wsl; do
   INSTALLED=$(apt list --installed "${META}" 2>/dev/null | grep installed)
   if [ -n "${INSTALLED}" ]; then
     fancy_message 0 "Detected ${META}."


### PR DESCRIPTION
By adding the ubuntu-wsl meta-package to the list of recognized desktop meta-packages users on WSL can try Rolling Rhino.