### PR TITLE
Try to re-run rolling-rhino with implicit sudo for unprivileged users

### DIFF
--- a/rolling-rhino
+++ b/rolling-rhino
@@ -34,13 +34,12 @@ function fancy_message() {
     esac
 }
 
-echo "Rolling Rhino 🦏"
-
-# Check if the user running the script is root
-if [ "$(id -u)" -ne 0 ]; then
-  fancy_message error "You need to be root."
-  exit 1
+# Check if the user running the script is root, ask for permissions otherwise
+if [ "$UID" -ne 0 ]; then
+  exec sudo "$0" "$@"
 fi
+
+echo "Rolling Rhino 🦏"
 
 # Take command line arguments
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
Instead of failing for unprivileged users, I propose that rolling-rhino should re-invoke itself through `sudo`. Just a suggestion, feel free to discard this if you don't think this is a good idea :smile: