### PR TITLE
Adding ZFS Snapshot support

### DIFF
--- a/rolling-rhino
+++ b/rolling-rhino
@@ -47,11 +47,13 @@ function take_zfs_snapshots() {
 	
 		if [[ $ZFS_ROOT_MOUNT == \/ && $ZFS_BOOT_MOUNT == \/boot ]]
 		then
-			echo "ZFS on root detected.  Taking snapshots before making any changes:"
-			echo "   rpool/ROOT@rollingrhino-\"$TIME_STAMP\""
-			echo "   bpool/BOOT@rollingrhino-\"$TIME_STAMP\""
+			echo ""
+			fancy_message info "ZFS on root detected.  Taking snapshots before making any changes:"
+			fancy_message info "rpool/ROOT@rollingrhino-$TIME_STAMP"
+			fancy_message info "bpool/BOOT@rollingrhino-$TIME_STAMP"
 			zfs snapshot -r rpool/ROOT@rollingrhino-"$TIME_STAMP"
 			zfs snapshot -r bpool/BOOT@rollingrhinoboot-"$TIME_STAMP"
+			echo ""
 		fi
 	fi
 }
@@ -138,7 +140,7 @@ read -p "Are you sure you want to start tracking the devel series? [y/N]" -n 1 -
 if [[ ${REPLY} =~ ^[Yy]$ ]]; then
 
     take_zfs_snapshots  
-    exit 1
+    
 
     cp  /etc/apt/sources.list /etc/apt/sources.list.${OS_CODENAME}
     cat << EOF > /etc/apt/sources.list

--- a/rolling-rhino
+++ b/rolling-rhino
@@ -34,6 +34,28 @@ function fancy_message() {
     esac
 }
 
+# Take a zfs snapshot if zfs on root
+function take_zfs_snapshots() {
+	ZFS_INSTALLED=$(dpkg-query --show --showformat='${db:Status-Status}\n' 'zfsutils-linux' 2>&1)
+
+	if [ $ZFS_INSTALLED == installed ]
+	then
+
+		ZFS_ROOT_MOUNT=$(zfs get -pH -o value mountpoint rpool 2>&1)
+		ZFS_BOOT_MOUNT=$(zfs get -pH -o value mountpoint bpool 2>&1)
+		TIME_STAMP=$(date)
+	
+		if [[ $ZFS_ROOT_MOUNT == \/ && $ZFS_BOOT_MOUNT == \/boot ]]
+		then
+			echo "ZFS on root detected.  Taking snapshots before making any changes:"
+			echo "   rpool/ROOT@rollingrhino-\"$TIME_STAMP\""
+			echo "   bpool/BOOT@rollingrhino-\"$TIME_STAMP\""
+			zfs snapshot -r rpool/ROOT@rollingrhino-"$TIME_STAMP"
+			zfs snapshot -r bpool/BOOT@rollingrhinoboot-"$TIME_STAMP"
+		fi
+	fi
+}
+
 echo "Rolling Rhino 🦏"
 
 # Check if the user running the script is root
@@ -54,6 +76,7 @@ while [ $# -gt 0 ]; do
       exit 1;;
   esac
 done
+
 
 if which lsb_release 1>/dev/null; then
   fancy_message info "lsb_release detected."
@@ -113,6 +136,10 @@ fancy_message info "All checks passed."
 read -p "Are you sure you want to start tracking the devel series? [y/N]" -n 1 -r
 
 if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+
+    take_zfs_snapshots  
+    exit 1
+
     cp  /etc/apt/sources.list /etc/apt/sources.list.${OS_CODENAME}
     cat << EOF > /etc/apt/sources.list
 # See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to


### PR DESCRIPTION
A first pass at adding in ZFS snapshot support. 

I'm not sure if this is the best way to detect if ZFS is installed on root.  Happy to take feedback and make edits.  Especially in regards to snapshot names, zfs on root detection, and output messaging.  Also, should we prompt the user if a snapshot is desired or just automatically take the snapshot as it is currently coded?  My thought is to just take the snapshot as there is no downside that I'm aware of.