### PR TITLE
Specify Rolling Rhino as the release version

### DIFF
--- a/rolling-rhino
+++ b/rolling-rhino
@@ -110,19 +110,24 @@ else
 fi
 
 fancy_message info "All checks passed."
-read -p "Are you sure you want to start tracking the devel series? [y/N]" -n 1 -r
+read -p "Are you sure you want to start tracking the devel series? [y/N] " -n 1 -r
+echo # Move the cursor to the next line before progressing for a nicer user experience
 
-if [[ ${REPLY} =~ ^[Yy]$ ]]; then
-    HOST_ARCH="$(uname --machine)"
-    if [ "${HOST_ARCH}" == "x86_64" ]; then
-      ARCHIVE="http://archive.ubuntu.com/ubuntu"
-      SEC_ARCHIVE="http://security.ubuntu.com/ubuntu"
-    else
-      ARCHIVE="http://ports.ubuntu.com/ubuntu-ports"
-      SEC_ARCHIVE="http://ports.ubuntu.com/ubuntu-ports"
-    fi
-    cp  /etc/apt/sources.list /etc/apt/sources.list.${OS_CODENAME}
-    cat << EOF > /etc/apt/sources.list
+if [[ ! ${REPLY} =~ ^[Yy]$ ]]; then
+  fancy_message info "You don't want to track the devel series. Quitting."
+  exit 1
+fi
+
+HOST_ARCH="$(uname --machine)"
+if [ "${HOST_ARCH}" == "x86_64" ]; then
+  ARCHIVE="http://archive.ubuntu.com/ubuntu"
+  SEC_ARCHIVE="http://security.ubuntu.com/ubuntu"
+else
+  ARCHIVE="http://ports.ubuntu.com/ubuntu-ports"
+  SEC_ARCHIVE="http://ports.ubuntu.com/ubuntu-ports"
+fi
+cp  /etc/apt/sources.list /etc/apt/sources.list.${OS_CODENAME}
+cat << EOF > /etc/apt/sources.list
 # See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
 # newer versions of the distribution.
 deb ${ARCHIVE} devel main restricted
@@ -174,13 +179,14 @@ deb ${SEC_ARCHIVE} devel-security multiverse
 # deb-src ${SEC_ARCHIVE} devel-security multiverse
 EOF
 
-    fancy_message info "Switching to devel series."
-    apt -y autoclean
-    apt -y clean
-    apt -y update
-    apt -y dist-upgrade
-    apt -y autoremove
-    fancy_message info "Your Rolling Rhino is ready."
+fancy_message info "Switching to devel series."
 
-    cat "$(dirname "$0")/logo.txt"
-fi
+apt -y autoclean
+apt -y clean
+apt -y update
+apt -y dist-upgrade
+apt -y autoremove
+
+fancy_message info "Your Rolling Rhino is ready."
+
+cat "$(dirname "$0")/logo.txt"

--- a/rolling-rhino
+++ b/rolling-rhino
@@ -187,6 +187,41 @@ apt -y update
 apt -y dist-upgrade
 apt -y autoremove
 
+dpkg-divert --local --rename --divert /etc/os-release.distrib /etc/os-release
+cat << EOF > /etc/os-release
+NAME="Ubuntu"
+VERSION="99.99 (Rolling Rhino)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu Rolling Rhino"
+VERSION_ID="99.99"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=rolling
+UBUNTU_CODENAME=rolling
+EOF
+
+dpkg-divert --local --rename --divert /etc/lsb-release.distrib /etc/lsb-release
+cat << EOF > /etc/lsb-release
+DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=99.99
+DISTRIB_CODENAME=rolling
+DISTRIB_DESCRIPTION="Ubuntu Rolling Rhino"
+EOF
+
+dpkg-divert --local --rename --divert /etc/issue.distrib /etc/issue
+cat << EOF > /etc/issue
+Ubuntu Rolling Rhino \n \l
+
+EOF
+
+dpkg-divert --local --rename --divert /etc/issue.net.distrib /etc/issue.net
+cat <<EOF > /etc/issue.net
+Ubuntu Rolling Rhino
+EOF
+
 fancy_message info "Your Rolling Rhino is ready."
 
 cat "$(dirname "$0")/logo.txt"


### PR DESCRIPTION
After this change, calls to lsb_release show Rolling Rhino:

```bash
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu Rolling Rhino
Release:	99.99
Codename:	rolling
```

And programs like neofetch show something similar:

![neofetch-rolling-rhino](https://user-images.githubusercontent.com/6955763/89823666-66117a00-db41-11ea-8681-e84561743000.png)