### PR TITLE
Check help argument before root check

### DIFF
--- a/rolling-rhino
+++ b/rolling-rhino
@@ -36,12 +36,6 @@ function fancy_message() {
 
 echo "Rolling Rhino 🦏"
 
-# Check if the user running the script is root
-if [ "$(id -u)" -ne 0 ]; then
-  fancy_message error "You need to be root."
-  exit 1
-fi
-
 # Take command line arguments
 while [ $# -gt 0 ]; do
   case "${1}" in
@@ -54,6 +48,12 @@ while [ $# -gt 0 ]; do
       exit 1;;
   esac
 done
+
+# Check if the user running the script is root
+if [ "$(id -u)" -ne 0 ]; then
+  fancy_message error "You need to be root."
+  exit 1
+fi
 
 if which lsb_release 1>/dev/null; then
   fancy_message info "lsb_release detected."


### PR DESCRIPTION
Changed the order, for first check the help argument.
No need to be root for displaying the usage message.